### PR TITLE
Add mute management API

### DIFF
--- a/src/main/java/cn/handyplus/chat/api/PlayerChatApi.java
+++ b/src/main/java/cn/handyplus/chat/api/PlayerChatApi.java
@@ -5,25 +5,32 @@ import cn.handyplus.chat.constants.ChatConstants;
 import cn.handyplus.chat.core.ChatUtil;
 import cn.handyplus.chat.core.HornUtil;
 import cn.handyplus.chat.enter.ChatPlayerChannelEnter;
+import cn.handyplus.chat.enter.ChatPlayerMuteEnter;
 import cn.handyplus.chat.event.PlayerChannelChatEvent;
 import cn.handyplus.chat.param.ChatChildParam;
 import cn.handyplus.chat.param.ChatParam;
 import cn.handyplus.chat.service.ChatPlayerChannelService;
+import cn.handyplus.chat.service.ChatPlayerMuteService;
 import cn.handyplus.lib.core.CollUtil;
+import cn.handyplus.lib.core.DateUtil;
 import cn.handyplus.lib.core.JsonUtil;
 import cn.handyplus.lib.core.StrUtil;
 import cn.handyplus.lib.util.BaseUtil;
 import cn.handyplus.lib.util.BcUtil;
 import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * API
@@ -252,6 +259,75 @@ public class PlayerChatApi {
         BcUtil.sendParamForward(player, param);
         // 发送消息
         HornUtil.sendMsg(player, param);
+    }
+
+    /**
+     * 禁言玩家
+     *
+     * @param player       玩家
+     * @param muteTime     禁言时长(秒)
+     * @param reason       禁言原因
+     * @param operatorName 操作者名称
+     * @return true成功
+     * @since 3.3.4
+     */
+    public boolean mutePlayer(@NotNull OfflinePlayer player, int muteTime, @Nullable String reason, @Nullable String operatorName) {
+        return mutePlayer(player.getUniqueId(), player.getName(), muteTime, reason, operatorName);
+    }
+
+    /**
+     * 禁言玩家
+     *
+     * @param playerUuid   玩家UUID
+     * @param playerName   玩家名称
+     * @param muteTime     禁言时长(秒)
+     * @param reason       禁言原因
+     * @param operatorName 操作者名称
+     * @return true成功
+     * @since 3.3.4
+     */
+    public boolean mutePlayer(@NotNull UUID playerUuid, @Nullable String playerName, int muteTime, @Nullable String reason, @Nullable String operatorName) {
+        if (muteTime <= 0) {
+            return false;
+        }
+        ChatPlayerMuteService.getInstance().removeByUuid(playerUuid);
+        ChatConstants.PLAYER_MUTE_CACHE.remove(playerUuid);
+
+        Date createTime = new Date();
+        String defaultOperatorName = PlayerChat.INSTANCE == null ? "PlayerChat" : PlayerChat.INSTANCE.getName();
+        ChatPlayerMuteEnter muteEnter = new ChatPlayerMuteEnter();
+        muteEnter.setPlayerName(playerName);
+        muteEnter.setPlayerUuid(playerUuid);
+        muteEnter.setReason(StrUtil.isEmpty(reason) ? BaseUtil.getLangMsg("muteDefaultReason") : reason);
+        muteEnter.setOperatorName(StrUtil.isEmpty(operatorName) ? defaultOperatorName : operatorName);
+        muteEnter.setMuteTime(muteTime);
+        muteEnter.setCreateTime(createTime);
+        muteEnter.setExpireTime(DateUtil.offset(createTime, Calendar.SECOND, muteTime));
+        return ChatPlayerMuteService.getInstance().add(muteEnter) > 0;
+    }
+
+    /**
+     * 解除禁言
+     *
+     * @param player 玩家
+     * @return true成功
+     * @since 3.3.4
+     */
+    public boolean unmutePlayer(@NotNull OfflinePlayer player) {
+        return unmutePlayer(player.getUniqueId());
+    }
+
+    /**
+     * 解除禁言
+     *
+     * @param playerUuid 玩家UUID
+     * @return true成功
+     * @since 3.3.4
+     */
+    public boolean unmutePlayer(@NotNull UUID playerUuid) {
+        int deleted = ChatPlayerMuteService.getInstance().removeByUuid(playerUuid);
+        ChatConstants.PLAYER_MUTE_CACHE.remove(playerUuid);
+        return deleted > 0;
     }
 
 }

--- a/src/main/java/cn/handyplus/chat/command/admin/MuteCommand.java
+++ b/src/main/java/cn/handyplus/chat/command/admin/MuteCommand.java
@@ -1,8 +1,6 @@
 package cn.handyplus.chat.command.admin;
 
-import cn.handyplus.chat.constants.ChatConstants;
-import cn.handyplus.chat.enter.ChatPlayerMuteEnter;
-import cn.handyplus.chat.service.ChatPlayerMuteService;
+import cn.handyplus.chat.api.PlayerChatApi;
 import cn.handyplus.lib.command.IHandyCommandEvent;
 import cn.handyplus.lib.core.DateUtil;
 import cn.handyplus.lib.core.MapUtil;
@@ -13,8 +11,6 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 
-import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 
 /**
@@ -51,21 +47,8 @@ public class MuteCommand implements IHandyCommandEvent {
         OfflinePlayer offlinePlayer = BaseUtil.getOfflinePlayer(playerName);
         AssertUtil.notNull(offlinePlayer, BaseUtil.getLangMsg("playerNotFoundMsg"));
 
-        // 删除旧的禁言记录
-        ChatPlayerMuteService.getInstance().removeByUuid(offlinePlayer.getUniqueId());
-        // 移除缓存
-        ChatConstants.PLAYER_MUTE_CACHE.remove(offlinePlayer.getUniqueId());
-
-        // 创建新的禁言记录
-        ChatPlayerMuteEnter muteEnter = new ChatPlayerMuteEnter();
-        muteEnter.setPlayerName(offlinePlayer.getName());
-        muteEnter.setPlayerUuid(offlinePlayer.getUniqueId());
-        muteEnter.setReason(reason);
-        muteEnter.setOperatorName(sender.getName());
-        muteEnter.setMuteTime(muteTime);
-        muteEnter.setCreateTime(new Date());
-        muteEnter.setExpireTime(DateUtil.offset(new Date(), Calendar.SECOND, muteTime));
-        ChatPlayerMuteService.getInstance().add(muteEnter);
+        boolean muted = PlayerChatApi.getInstance().mutePlayer(offlinePlayer, muteTime, reason, sender.getName());
+        AssertUtil.isTrue(muted, BaseUtil.getLangMsg("timeFormatFailureMsg"));
         HashMap<String, String> map = MapUtil.of("${player}", playerName, "${reason}", reason, "${time}", muteTime.toString());
         MessageUtil.sendMessage(sender, BaseUtil.getLangMsg("muteSuccessMsg", map));
         // 通知被禁言玩家

--- a/src/main/java/cn/handyplus/chat/command/admin/UnmuteCommand.java
+++ b/src/main/java/cn/handyplus/chat/command/admin/UnmuteCommand.java
@@ -1,7 +1,6 @@
 package cn.handyplus.chat.command.admin;
 
-import cn.handyplus.chat.constants.ChatConstants;
-import cn.handyplus.chat.service.ChatPlayerMuteService;
+import cn.handyplus.chat.api.PlayerChatApi;
 import cn.handyplus.lib.command.IHandyCommandEvent;
 import cn.handyplus.lib.core.MapUtil;
 import cn.handyplus.lib.util.AssertUtil;
@@ -43,15 +42,13 @@ public class UnmuteCommand implements IHandyCommandEvent {
 
         OfflinePlayer offlinePlayer = BaseUtil.getOfflinePlayer(playerName);
         AssertUtil.notNull(offlinePlayer, BaseUtil.getLangMsg("playerNotFoundMsg"));
-        int deleted = ChatPlayerMuteService.getInstance().removeByUuid(offlinePlayer.getUniqueId());
-        // 移除缓存
-        ChatConstants.PLAYER_MUTE_CACHE.remove(offlinePlayer.getUniqueId());
+        boolean unmuted = PlayerChatApi.getInstance().unmutePlayer(offlinePlayer);
 
         Map<String, String> map = MapUtil.of("${player}", playerName);
-        String msg = BaseUtil.getLangMsg(deleted > 0 ? "unmuteSuccessMsg" : "unmuteNotFoundMsg", map);
+        String msg = BaseUtil.getLangMsg(unmuted ? "unmuteSuccessMsg" : "unmuteNotFoundMsg", map);
         MessageUtil.sendMessage(sender, msg);
         // 通知被解除禁言玩家
-        if (deleted > 0) {
+        if (unmuted) {
             MessageUtil.sendMessage(offlinePlayer.getUniqueId(), BaseUtil.getLangMsg("unmutedNotifyMsg"));
         }
     }


### PR DESCRIPTION
## Summary
- Add public PlayerChatApi methods for muting and unmuting players
- Keep mute database records and PLAYER_MUTE_CACHE in sync
- Reuse the new API from existing mute/unmute commands

## Verification
- git diff --cached --check
- mvn compile could not complete locally because private/extra Maven repositories from CI settings are unavailable